### PR TITLE
Fix bug #85 ( UserUpdate should filter by User)

### DIFF
--- a/supplies_tracker/templates/users/show.html.haml
+++ b/supplies_tracker/templates/users/show.html.haml
@@ -14,7 +14,7 @@
 
           %label.pull-right.btn
             .btn-group
-              %a.btn.btn-primary{ href: "{% url 'user_update' user.id %}" }
+              %a.btn.btn-primary{ href: "{% url 'user_update' %}" }
                 .fa.fa-edit
                 Edit Profile
 

--- a/supplies_tracker/urls.py
+++ b/supplies_tracker/urls.py
@@ -58,7 +58,7 @@ urlpatterns = [
     url(r'^logout/$', auth_views.logout, {'next_page': 'login'}, name='logout'),
     url(r'^signup/$', supplies_tracker_views.signup, name='signup'),
     url(r'^users/(?P<user_id>[0-9]+)/$', views.users_show, name='users_show'),
-    url(r'^users/(?P<pk>[0-9]+)/edit$', views.UserUpdate.as_view(), name='user_update'),
+    url(r'^users/edit$', views.UserUpdate.as_view(), name='user_update'),
 ]
 
 urlpatterns += staticfiles_urlpatterns()

--- a/supplies_tracker/views.py
+++ b/supplies_tracker/views.py
@@ -321,10 +321,15 @@ class UserUpdate(LoginRequiredMixin, UpdateView):
     template_name = 'users/edit.html.haml'
     success_url = reverse_lazy('users_show')
 
-    def get_success_url(self):
-        user_id = self.kwargs['pk']
-        return reverse_lazy('users_show', kwargs={'user_id': user_id})
+    def get_object(self):
+        """
+        Only return the User object that belongs to the logged-in User
+        """
+        return self.request.user
 
+    def get_success_url(self):
+        user_id = self.request.user.pk
+        return reverse_lazy('users_show', kwargs={'user_id': user_id} )
 
 @login_required
 def items_add_to_storage(request, item_id):


### PR DESCRIPTION
1. Change User Update view URL to not use since User should be only allowed to edit his own Profile.
2. Add get_object to UserUpdate view that returns the logged in user.
3. Update template to use new url (no args)

New PR coming from a branch as it should have been. 